### PR TITLE
feat: [CDS-100473]: gitops agent upgrader support for registry mirrors

### DIFF
--- a/templates/gitops-agent/deployment.yaml
+++ b/templates/gitops-agent/deployment.yaml
@@ -55,20 +55,20 @@ spec:
       containers:
       - command:
           - /app/agent
+          {{- with .Values.agent.logFormat }}
+          - --logformat
+          - {{ . | quote }}
+          {{- end }}
+          {{- with .Values.agent.logLevel }}
+          - --loglevel
+          - {{ . | quote }}
+          {{- end }}
+          {{- with .Values.agent.extraArgs }}
+            {{- toYaml . | nindent 8 }}
+          {{- end }}
         name: {{ .Values.agent.name }}
         image: {{ .Values.agent.image.repository }}:{{ .Values.agent.image.tag }}
         imagePullPolicy: {{ .Values.agent.image.imagePullPolicy }}
-        {{- with .Values.agent.logFormat }}
-        - --logformat
-        - {{ . | quote }}
-        {{- end }}
-        {{- with .Values.agent.logLevel }}
-        - --loglevel
-        - {{ . | quote }}
-        {{- end }}
-        {{- with .Values.agent.extraArgs }}
-          {{- toYaml . | nindent 8 }}
-        {{- end }}
         envFrom:
           - configMapRef:
               name: {{ .Values.agent.name }}

--- a/templates/upgrader/harness-upgrader-cm.yaml
+++ b/templates/upgrader/harness-upgrader-cm.yaml
@@ -17,6 +17,9 @@ data:
   UPGRADER_CLIENT_CERTIFICATE_FILE_PATH: {{ .Values.upgrader.config.clientCertificateFilePath }}
   UPGRADER_CLIENT_CERTIFICATE_KEY_FILE_PATH: {{ .Values.upgrader.config.clientCertificateKeyFilePath }}
   {{- end }}
+  {{- if ne .Values.upgrader.config.registryMirror "" }}
+  UPGRADER_REGISTRY_MIRROR: {{ .Values.upgrader.config.registryMirror }}
+  {{- end}}
   UPGRADER_GITOPS_AGENT_HTTP_TARGET: {{ .Values.harness.gitopsServerHost }}
   UPGRADER_GITOPS_USE_V2: "true"
   UPGRADER_GITOPS_ALL: "{{ .Values.upgrader.config.upgradeAll }}"

--- a/values.yaml
+++ b/values.yaml
@@ -362,6 +362,7 @@ upgrader:
   config:
     # -- Upgrade all related images in GitOps Agent including Argo CD, Redis etc.
     upgradeAll: false
+    registryMirror: ""
     # -- Cert Paths for mTLS in upgrader
     clientCertificateFilePath: /etc/mtls/client.crt
     clientCertificateKeyFilePath: /etc/mtls/client.key


### PR DESCRIPTION
Similar to the support for harness delegate upgrader, this will allow the gitops agent upgrader also to use a custom private registry or registry mirror if user sets it in the configmap of upgrader.