### PR TITLE
fix: [CDS-103262]: Add checksum for agent deployment secrets

### DIFF
--- a/charts/templates/gitops-agent/deployment.yaml
+++ b/charts/templates/gitops-agent/deployment.yaml
@@ -27,6 +27,7 @@ spec:
         {{ $key }}: {{ $value | quote }}
         {{- end }}
         {{- end }}
+        checksum/secrets: {{ include (print $.Template.BasePath "/gitops-agent/secret.yaml") . | sha256sum }}
       labels:
         {{- include "harness.agentLabels" (dict "context" . "component" .Values.agent.name "name" .Values.agent.name) | nindent 8 }}
         {{- with .Values.agent.podLabels }}


### PR DESCRIPTION
Add sha256 checksum for all gitops deployment related secrets

- [x] helm template test .
<img width="867" alt="Screenshot 2024-11-13 at 15 32 56" src="https://github.com/user-attachments/assets/c2d07a4c-0709-41c5-85b6-1d4c47f0b6bd">

- [x] helm template test . --set harness.secrets.agentSecret=nil
<img width="831" alt="Screenshot 2024-11-13 at 15 33 21" src="https://github.com/user-attachments/assets/02be5c5e-3996-4eef-abb4-2d671c941319">

- [x] helm template test . --set harness.secrets.agentSecret=some-secret
<img width="946" alt="Screenshot 2024-11-13 at 15 33 52" src="https://github.com/user-attachments/assets/cc07cd09-b78c-4b03-8985-15d725722438">
