### PR TITLE
Updating Values to use no proxy in the config

### DIFF
--- a/charts/templates/gitops-agent/configmap.yaml
+++ b/charts/templates/gitops-agent/configmap.yaml
@@ -35,7 +35,7 @@ data:
   {{-  if .Values.agent.proxy.enabled }}
   HTTPS_PROXY: {{ .Values.agent.proxy.httpsProxy }}
   HTTP_PROXY: {{ .Values.agent.proxy.httpProxy }}
-  NO_PROXY: localhost,{{ .Values.harness.configMap.argocd.repoServerSvc | default "argocd-repo-server" }},{{ include "redisServer" . | default "argocd-redis" }},127.0.0.1,$(KUBERNETES_SERVICE_HOST),kubernetes.default.svc,{{ .Values.agent.name | default "gitops-agent" }}
+  NO_PROXY: localhost,{{ .Values.harness.configMap.argocd.repoServerSvc | default "argocd-repo-server" }},{{ include "redisServer" . | default "argocd-redis" }},127.0.0.1,$(KUBERNETES_SERVICE_HOST),kubernetes.default.svc,{{ .Values.agent.name | default "gitops-agent" }}{{ if .Values.agent.proxy.noProxy }},{{ .Values.agent.proxy.noProxy }}{{ end }}
   {{- end }}
   REDIS_SERVER: {{ include "redisServer" . }}:6379
   GITOPS_AGENT_NUM_FETCHERS: "{{ .Values.agent.numFetchers }}"

--- a/charts/templates/upgrader/cronjob.yaml
+++ b/charts/templates/upgrader/cronjob.yaml
@@ -39,7 +39,7 @@ spec:
                 - name: PROXY_PASSWORD
                   value: {{ .Values.upgrader.config.proxyPassword }}
                 - name: NO_PROXY
-                  value: localhost,{{ .Values.harness.configMap.argocd.repoServerSvc | default "argocd-repo-server" }},{{ include "redisServer" . | default "argocd-redis" }},127.0.0.1,$(KUBERNETES_SERVICE_HOST),kubernetes.default.svc,{{ .Values.agent.name | default "gitops-agent" }}
+                  value: localhost,{{ .Values.harness.configMap.argocd.repoServerSvc | default "argocd-repo-server" }},{{ include "redisServer" . | default "argocd-redis" }},127.0.0.1,$(KUBERNETES_SERVICE_HOST),kubernetes.default.svc,{{ .Values.agent.name | default "gitops-agent" }}{{ if .Values.agent.proxy.noProxy }},{{ .Values.agent.proxy.noProxy }}{{ end }}
             {{- end }}
                 - name: UPGRADER_TOKEN
                   valueFrom:

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -137,6 +137,9 @@ agent:
     # -- Add HTTPS proxy
     httpsProxy: ""
 
+    # -- Extra hosts/CIDRs to bypass the proxy, comma-separated (appended to the built-in defaults)
+    noProxy: ""
+
   ## Create an OpenShift agent
   openshift:
     enabled: false
@@ -411,7 +414,6 @@ upgrader:
     proxyHost: ""
     proxyPort: ""
     proxyScheme: ""
-    noProxy: ""
     proxyUser: ""
     proxyPassword: ""
 


### PR DESCRIPTION
Adding values to be able to append the noPorxy. 

```
➜  gitops-helm-byoa git:(feature/no-proxy-values)  helm lint charts/
==> Linting charts/
[INFO] Chart.yaml: icon is recommended

1 chart(s) linted, 0 chart(s) failed
```

```
➜  gitops-helm-byoa git:(feature/no-proxy-values)   helm template t charts/ \
    --set agent.proxy.enabled=true \
    --set agent.proxy.httpProxy=http://dummy:3128 \
    --set agent.proxy.httpsProxy=http://dummy:3128 \
    --show-only templates/gitops-agent/configmap.yaml | grep NO_PROXY

  NO_PROXY: localhost,argocd-repo-server,argocd-redis,127.0.0.1,$(KUBERNETES_SERVICE_HOST),kubernetes.default.svc,gitops-agent
```

```
➜  gitops-helm-byoa git:(feature/no-proxy-values)   helm template t charts/ \
    --set agent.proxy.enabled=true \
    --set agent.proxy.httpProxy=http://dummy:3128 \
    --set agent.proxy.httpsProxy=http://dummy:3128 \
    --set 'agent.proxy.noProxy=10.0.0.0/8\,.internal.example.com' \
    --show-only templates/gitops-agent/configmap.yaml | grep NO_PROXY

  NO_PROXY: localhost,argocd-repo-server,argocd-redis,127.0.0.1,$(KUBERNETES_SERVICE_HOST),kubernetes.default.svc,gitops-agent,10.0.0.0/8,.internal.example.com
```